### PR TITLE
readme file name and flow chart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GITSUB
 
-# wireframes
+# Wireframes
 
 https://www.figma.com/design/8vIX1yEXd2UxdWARbWqAje/GitSub?node-id=0-1&node-type=canvas
 
@@ -10,6 +10,7 @@ https://www.figma.com/design/8vIX1yEXd2UxdWARbWqAje/GitSub?node-id=0-1&node-type
 
 https://github.com/nss-evening-cohort-29/flamingo-gitsub/blob/64822bee21f439b3867ffe212f1aefb8489058fd/dbdiagram.png
 
-# flow chart
+# Flow Chart
 
-(still working, very draft): https://www.figma.com/board/o44GvPeZBRiKihCvHfwpl0/Untitled?node-id=0-1&node-type=canvas&t=aOt1pJI9CJMZvvVu-0
+https://www.figma.com/board/o44GvPeZBRiKihCvHfwpl0/gitsub-user-flowchart?node-id=0-1&t=mIxTyhvM0k47b6Yj-1
+<img width="1148" alt="image of user flow chart" src="https://www.figma.com/board/o44GvPeZBRiKihCvHfwpl0/gitsub-user-flowchart?node-id=0-1&t=mIxTyhvM0k47b6Yj-1">


### PR DESCRIPTION
## Description
changed readme name. replaced figma link for user flow chart
## Related Issue
readme not displaying in GH. flow chart link broken
## Motivation and Context
read me needs to be named README.md in order to display on GH. flow chart link wasn't working for non-owner

## How Can This Be Tested?

- flowchart accessibility: can be tested by having a non-owner click link. could log out of figma and click link to ensure it works as non-owner. (both alyssa and andrew have ownership status on figma flowcahrt)

- readme visibility in GH: will need to be merged to be tested. once merged, can check that the readme displays in GH by default (not by clicking on the readme file). 